### PR TITLE
Fix freeze when stopping tracking from watch

### DIFF
--- a/SleepGarmin-watch/source/SleepApp.mc
+++ b/SleepGarmin-watch/source/SleepApp.mc
@@ -121,9 +121,8 @@ using Toybox.Math as Math;
     	if (Sys.getDeviceSettings().phoneConnected && !fakeTransmit) {
                 Comm.transmit("STOPPING", null, new SleepNowListener("STOPPING"));
 
-		} else if (!Sys.getDeviceSettings().phoneConnected){
-				exitTimer(20);
-		}
+		} 
+		exitTimer(20);
     }
     
     function forceExit(){


### PR DESCRIPTION
This fixes #12 .
Previously when stopping tracking from watch the app would freeze because the exit timer is not started. 